### PR TITLE
expose add font family method

### DIFF
--- a/Source/HtmlRenderer.PdfSharp.Core/Adapters/PdfSharpAdapter.cs
+++ b/Source/HtmlRenderer.PdfSharp.Core/Adapters/PdfSharpAdapter.cs
@@ -127,8 +127,10 @@ namespace TheArtOfDev.HtmlRenderer.PdfSharp.Adapters
         protected override RFont CreateFontInt(RFontFamily family, double size, RFontStyle style)
         {
             var fontStyle = (XFontStyle)((int)style);
-            var xFont = new XFont(((FontFamilyAdapter)family).FontFamily.Name, size, fontStyle, new XPdfFontOptions(PdfFontEncoding.Unicode));
+            string fontName = family is FontFamilyAdapter adapter ? adapter.FontFamily.Name : family.Name;
+            var xFont = new XFont(fontName, size, fontStyle, new XPdfFontOptions(PdfFontEncoding.Unicode));
             return new FontAdapter(xFont);
         }
+
     }
 }

--- a/Source/HtmlRenderer.PdfSharp.Core/PdfGenerator.cs
+++ b/Source/HtmlRenderer.PdfSharp.Core/PdfGenerator.cs
@@ -14,6 +14,7 @@ using PdfSharpCore;
 using PdfSharpCore.Drawing;
 using PdfSharpCore.Pdf;
 using System;
+using TheArtOfDev.HtmlRenderer.Adapters;
 using TheArtOfDev.HtmlRenderer.Core;
 using TheArtOfDev.HtmlRenderer.Core.Entities;
 using TheArtOfDev.HtmlRenderer.Core.Utils;
@@ -42,6 +43,11 @@ namespace TheArtOfDev.HtmlRenderer.PdfSharp
             ArgChecker.AssertArgNotNullOrEmpty(toFamily, "toFamily");
 
             PdfSharpAdapter.Instance.AddFontFamilyMapping(fromFamily, toFamily);
+        }
+
+        public static void AddFontFamily(RFontFamily fontFamily)
+        {
+            PdfSharpAdapter.Instance.AddFontFamily(fontFamily);
         }
 
         /// <summary>


### PR DESCRIPTION
In order to add custom font that loaded locally in my project, it's essential to insert the font name into the exisiting fonts dictionary.
Thus I exposed the AddFontFamily method to the PdfGenerator class, in order to add my custom fonts to the _exisitingFont dicitonary and use those fonts instead of the default Segoe UI.

I havn't found another way to use custom fonts on non-windows machines.